### PR TITLE
Added tooltip & changed headers in result module

### DIFF
--- a/frontend/modules/student/views/result/discipline.php
+++ b/frontend/modules/student/views/result/discipline.php
@@ -6,7 +6,6 @@
 use yii\grid\GridView;
 use yii\helpers\Html;
 
-
 $this->title = 'Результаты';
 
 $this->params['breadcrumbs'][] = [
@@ -24,7 +23,7 @@ $this->params['breadcrumbs'][] = [
 
 $this->params['breadcrumbs'][] = $this->title;
 $this->params['model'] = $disciplineSemester;
-$this->params['header'] = "{$disciplineSemester->idDiscipline->fullName}, {$disciplineSemester->semester} семестр";
+$this->params['header'] = "{$disciplineSemester->idDiscipline->idProgram->name}, {$disciplineSemester->idDiscipline->fullName}, {$disciplineSemester->semester} семестр";
 ?>
 
 <?= GridView::widget([
@@ -37,7 +36,10 @@ $this->params['header'] = "{$disciplineSemester->idDiscipline->fullName}, {$disc
             'header' => 'Студент',
             'value' => function($model, $key, $index, $column) {
                            if ($model['id_result']) {
-                               return Html::a($model['name'],['result/view-discipline','id' => $model['id_result']]);
+                               return Html::a($model['name'],['result/view-discipline','id' => $model['id_result']],
+							   ['data-toggle' => 'tooltip',
+							    'title' => 'Подробнее',
+							   ]);
                            }
                            else {
                                return $model['name'];

--- a/frontend/modules/student/views/result/student.php
+++ b/frontend/modules/student/views/result/student.php
@@ -29,7 +29,7 @@ $this->params['breadcrumbs'][] = [
 
 $this->params['breadcrumbs'][] = $this->title;
 $this->params['model'] = $student;
-$this->params['header'] = "{$student->studentName}, {$student->course} курс";
+$this->params['header'] = "{$program->name}, {$student->studentName}, {$student->course} курс";
 
 ?>
 
@@ -47,7 +47,6 @@ $this->params['header'] = "{$student->studentName}, {$student->course} курс"
                                return Html::a($disciplineName,['result/view-student','id' => $model['id_result']],
 							   ['data-toggle' => 'tooltip',
 							    'title' => 'Подробнее',
-							   //В надобности этой подсказки я сомневаюсь
 							   ]);
                            }
                            else {


### PR DESCRIPTION
С гридом так и задумано. он не помещается в один экран, но прокручивается во всех направлениях. На смартфоне получается удобно его двигать пальцем, а у компьютеров нет таких узких экранов, но даже в таком случае там будет полоса прокрутки.

Сайдбары на узком экране располагаются друг под другом и сжимаются. Правда, у меня нет примера заполненного портфолио.
